### PR TITLE
fix progress bar number display issue

### DIFF
--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -15,16 +15,16 @@
 
 <div class="row">
     <div class="col-sm-2 col-xs-3">Running</div>
-    <div class="progress progress-custom col-sm-8 col-xs-7">
-        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent) %>"></div>
-        <div class="col-sm-2 col-xs-2 pull-left"><%= showqer.active_jobs %></div>
+    <div class="progress progress-custom col-sm-10 col-xs-9">
+        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.9) %>"></div>
+        <div class="col-sm-1 col-xs-1 pull-left"><%= showqer.active_jobs %></div>
      </div>
 </div>
 
 <div class="row">
     <div class="col-sm-2 col-xs-3">Queued</div>
-    <div class="progress progress-custom col-sm-8 col-xs-7">
-            <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent) %>"></div>
-            <div class="col-sm-2 col-xs-2 pull-left"><%= showqer.eligible_jobs %></div>
+    <div class="progress progress-custom col-sm-10 col-xs-9">
+          <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.9) %>"></div>
+          <div class="col-sm-1 col-xs-1 pull-left"><%= showqer.eligible_jobs %></div>
     </div>
 </div>

--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -11,20 +11,20 @@
     </div>
 </div>
 <hr>
-<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
-<div class="col-sm-2">
-  <div class="pull-right">Running</div>
-</div>
-<div class="progress progress-custom">
-  <div class="progress-bar col-sm-10" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent) %>">
-    <div><%= showqer.active_jobs %></div>
+<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4>
+<div class="row">
+  <div class="col-sm-2 col-xs-3">Running</div>
+  <div class="progress progress-custom col-sm-8 col-xs-7">
+    <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent) %>">
+    </div>
   </div>
+  <div class="col-sm-2 col-xs-2"><%= showqer.active_jobs %></div>
 </div>
-<div class="col-sm-2">
-  <div class="pull-right">Queued</div>
-</div>
-<div class="progress progress-custom">
-  <div class="progress-bar progress-bar-info col-sm-10" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent) %>">
-    <div><%= showqer.eligible_jobs %></div>
+<div class="row">
+  <div class="col-sm-2 col-xs-3">Queued</div>
+  <div class="progress progress-custom col-sm-8 col-xs-7">
+    <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent) %>">
+    </div>
   </div>
+  <div class="col-sm-2 col-xs-2"><%= showqer.eligible_jobs %></div>
 </div>

--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -16,7 +16,7 @@
 <div class="row">
     <div class="col-sm-2 col-xs-3">Running</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
-        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.9) %>"></div>
+        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.86) %>"></div>
         <div class="col-sm-1 col-xs-1 pull-left"><%= showqer.active_jobs %></div>
      </div>
 </div>
@@ -24,7 +24,7 @@
 <div class="row">
     <div class="col-sm-2 col-xs-3">Queued</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
-          <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.9) %>"></div>
+          <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.86) %>"></div>
           <div class="col-sm-1 col-xs-1 pull-left"><%= showqer.eligible_jobs %></div>
     </div>
 </div>

--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -16,15 +16,15 @@
 <div class="row">
     <div class="col-sm-2 col-xs-3">Running</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
-        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.88) %>"></div>
-        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px 5px"><%= showqer.active_jobs %></div>
+        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.82) %>"></div>
+        <div style="float:left; padding-left:5px"><%= showqer.active_jobs %></div>
      </div>
 </div>
 
 <div class="row">
     <div class="col-sm-2 col-xs-3">Queued</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
-        <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.88) %>"></div>
-        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px 5px"><%= showqer.eligible_jobs %></div>
+        <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.82) %>"></div>
+        <div style="float:left; padding-left:5px"><%= showqer.eligible_jobs %></div>
     </div>
 </div>

--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -17,7 +17,7 @@
     <div class="col-sm-2 col-xs-3">Running</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
         <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.88) %>"></div>
-        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px"><%= showqer.active_jobs %></div>
+        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px 5px"><%= showqer.active_jobs %></div>
      </div>
 </div>
 
@@ -25,6 +25,6 @@
     <div class="col-sm-2 col-xs-3">Queued</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
         <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.88) %>"></div>
-        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px"><%= showqer.eligible_jobs %></div>
+        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px 5px"><%= showqer.eligible_jobs %></div>
     </div>
 </div>

--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -11,20 +11,20 @@
     </div>
 </div>
 <hr>
-<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4>
+<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
+
 <div class="row">
-  <div class="col-sm-2 col-xs-3">Running</div>
-  <div class="progress progress-custom col-sm-8 col-xs-7">
-    <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent) %>">
-    </div>
-  </div>
-  <div class="col-sm-2 col-xs-2"><%= showqer.active_jobs %></div>
+    <div class="col-sm-2 col-xs-3">Running</div>
+    <div class="progress progress-custom col-sm-8 col-xs-7">
+        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent) %>"></div>
+        <div class="col-sm-2 col-xs-2 pull-left"><%= showqer.active_jobs %></div>
+     </div>
 </div>
+
 <div class="row">
-  <div class="col-sm-2 col-xs-3">Queued</div>
-  <div class="progress progress-custom col-sm-8 col-xs-7">
-    <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent) %>">
+    <div class="col-sm-2 col-xs-3">Queued</div>
+    <div class="progress progress-custom col-sm-8 col-xs-7">
+            <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent) %>"></div>
+            <div class="col-sm-2 col-xs-2 pull-left"><%= showqer.eligible_jobs %></div>
     </div>
-  </div>
-  <div class="col-sm-2 col-xs-2"><%= showqer.eligible_jobs %></div>
 </div>

--- a/app/views/clusters/_node_status.html.erb
+++ b/app/views/clusters/_node_status.html.erb
@@ -16,15 +16,15 @@
 <div class="row">
     <div class="col-sm-2 col-xs-3">Running</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
-        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.86) %>"></div>
-        <div class="col-sm-1 col-xs-1 pull-left"><%= showqer.active_jobs %></div>
+        <div class="progress-bar" role="progressbar" style="width:<%= number_to_percentage(showqer.active_percent*0.88) %>"></div>
+        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px"><%= showqer.active_jobs %></div>
      </div>
 </div>
 
 <div class="row">
     <div class="col-sm-2 col-xs-3">Queued</div>
     <div class="progress progress-custom col-sm-10 col-xs-9">
-          <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.86) %>"></div>
-          <div class="col-sm-1 col-xs-1 pull-left"><%= showqer.eligible_jobs %></div>
+        <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= number_to_percentage(showqer.eligible_percent*0.88) %>"></div>
+        <div class="col-sm-1 col-xs-1 pull-left" style="padding:0px"><%= showqer.eligible_jobs %></div>
     </div>
 </div>


### PR DESCRIPTION
The numbers of running and queued jobs are moved to the right side of the progress bar.

![systemstatus_progressbar1](https://user-images.githubusercontent.com/22674713/40922546-753527e2-67e0-11e8-8654-d69f9a508cd3.JPG)

Small viewport:
![systemstatus_progressbar2](https://user-images.githubusercontent.com/22674713/40922547-754350b0-67e0-11e8-8cae-0aa6839c2292.JPG)

close #48 


