### PR TITLE
Grafana support

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -66,12 +66,11 @@ get '/clusters/:id/:time/:type' do
   graph_time.keys.include?(params[:time].to_sym) ? @time=params[:time].to_sym : @time=:hour
   graph_types.keys.include?(params[:type].to_sym) ? @type=params[:type].to_sym : @type=:report_moab_nodes
   cluster = CLUSTERS[@id]
-  if cluster.nil?
+  if cluster.nil? || ! cluster.custom_config.key?(:ganglia)
     raise Sinatra::NotFound
-  elsif cluster.custom_config.key?(:ganglia)
-    @provider = Ganglia.new(cluster).send(@time)
-    erb :system_status
   end
+  @ganglia = Ganglia.new(cluster).send(@time)
+  erb :system_status
 end
 
 

--- a/app.rb
+++ b/app.rb
@@ -14,7 +14,7 @@ require_relative 'lib/ganglia'
 begin
   CLUSTERS = OodCore::Clusters.new(OodCore::Clusters.load_file(ENV['OOD_CLUSTERS'] || '/etc/ood/config/clusters.d').select(&:job_allow?)
             .select { |c| c.custom_config[:moab] }
-            .select { |c| c.custom_config[:ganglia] }
+            .select { |c| c.custom_config[:ganglia] || c.custom_config[:grafana] }
             .reject { |c| c.metadata.hidden }
           )
 rescue OodCore::ConfigurationNotFound
@@ -68,8 +68,8 @@ get '/clusters/:id/:time/:type' do
   cluster = CLUSTERS[@id]
   if cluster.nil?
     raise Sinatra::NotFound
-  else
-    @ganglia = Ganglia.new(cluster).send(@time)
+  elsif cluster.custom_config.key?(:ganglia)
+    @provider = Ganglia.new(cluster).send(@time)
     erb :system_status
   end
 end

--- a/lib/moab_showq_client.rb
+++ b/lib/moab_showq_client.rb
@@ -4,7 +4,7 @@
 # @version 0.1.0
 class MoabShowqClient
 
-  attr_reader :active_jobs, :eligible_jobs, :blocked_jobs, :procs_used, :procs_avail, :nodes_used, :nodes_avail, :error_message, :cluster_id, :cluster_title, :friendly_error_message
+  attr_reader :active_jobs, :eligible_jobs, :blocked_jobs, :procs_used, :procs_avail, :nodes_used, :nodes_avail, :error_message, :dashboard_url, :cluster_id, :cluster_title, :friendly_error_message
 
   # Set the object to the server.
   #
@@ -13,6 +13,9 @@ class MoabShowqClient
   # @return [MoabShowqClient] self
   def initialize(cluster)
     @server = cluster.custom_config[:moab]
+    if cluster.custom_config.key?(:grafana)
+      @dashboard_url = cluster.custom_config[:grafana]['dashboard']
+    end
     @cluster_id = cluster.id
     @cluster_title = cluster.metadata.title || cluster.id.titleize
     self

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,7 +2,11 @@
 <!-- node status on /clusters page -->
 <% @clusters.each_with_index do |cluster, index | %>
       <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
+        <% if cluster.dashboard_url %>
+          <a href = "<%= cluster.dashboard_url %>" target="_blank">
+        <% else %>
           <a href = "<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
+        <% end %>
             <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable">
               <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
               <%= erb :_node_status, :locals => { :showqer => cluster, :gpustats => @gpustats[index].setup } %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -127,7 +127,11 @@
         <ul class="nav navbar-nav">
           <% CLUSTERS.each do |cluster| %>
               <li class="<%= 'active' if @ganglia && @ganglia.server_id == cluster.id %>">
-                <a href="<%= url("/clusters/#{cluster.id}/hour/report_moab_nodes") %>"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
+                <% if cluster.custom_config.key?(:ganglia) %>
+                  <a href="<%= url("/clusters/#{cluster.id}/hour/report_moab_nodes") %>"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
+                <% elsif cluster.custom_config.key?(:grafana) %>
+                  <a href="<%= cluster.custom_config[:grafana]['dashboard'] %>" target="_blank"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
+                <% end %>
               </li>
           <% end %>
         </ul>


### PR DESCRIPTION
This replaces the cluster graph links with links to a configured dashboard.

Example config block in cluster YAML:

```yaml
v2:
  custom:
    grafana:
      dashboard: https://grafana.osc.edu/d/paThaJae6hia/ondemand-system-status?orgId=3&from=now-24h&to=now&var-cluster=pitzer
```

The alternative is just adding new menu item which links to this dashboard as a dedicated app. I could do both really.  The dashboard can not link back to OnDemand because we'd have to hardcode in like https://ondemand.osc.edu but that would be invalid for test instances and awesim.