### PR TITLE
Use updated grafana config schema

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -73,6 +73,17 @@ get '/clusters/:id/:time/:type' do
   erb :system_status
 end
 
+get '/clusters/:id/grafana' do
+  @id = params[:id].to_sym
+  cluster = CLUSTERS[@id]
+  if cluster.nil? || ! cluster.custom_config.key?(:grafana)
+    raise Sinatra::NotFound
+  end
+  grafana = cluster.custom_config[:grafana]
+  dashboard_url = "#{grafana['dashboard']['uid']}/#{grafana['dashboard']['name']}"
+  grafana_url = "#{grafana['host']}/d/#{dashboard_url}?orgId=#{grafana['orgId']}&var-cluster=#{@id}"
+  redirect(grafana_url)
+end
 
 # redirect to /clusters/:id/hour/report_moab_nodes page
 get '/clusters/:id*' do

--- a/app.rb
+++ b/app.rb
@@ -81,7 +81,8 @@ get '/clusters/:id/grafana' do
   end
   grafana = cluster.custom_config[:grafana]
   dashboard_url = "#{grafana['dashboard']['uid']}/#{grafana['dashboard']['name']}"
-  grafana_url = "#{grafana['host']}/d/#{dashboard_url}?orgId=#{grafana['orgId']}&var-cluster=#{@id}"
+  theme = grafana['theme'] || 'light'
+  grafana_url = "#{grafana['host']}/d/#{dashboard_url}?orgId=#{grafana['orgId']}&theme=#{theme}&var-cluster=#{@id}"
   redirect(grafana_url)
 end
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -130,7 +130,7 @@
                 <% if cluster.custom_config.key?(:ganglia) %>
                   <a href="<%= url("/clusters/#{cluster.id}/hour/report_moab_nodes") %>"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
                 <% elsif cluster.custom_config.key?(:grafana) %>
-                  <a href="<%= cluster.custom_config[:grafana]['dashboard'] %>" target="_blank"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
+                  <a href="<%= url("/clusters/#{cluster.id}/grafana") %>" target="_blank"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
                 <% end %>
               </li>
           <% end %>


### PR DESCRIPTION
Uses updated grafana config schema identical to https://github.com/OSC/ondemand/pull/400

Tested with this:

```yaml
    grafana:
      host: "https://grafana.osc.edu"
      orgId: 3
      dashboard:
        name: ondemand-clusters
        uid: aaba6Ahbauquag
        panels:
          cpu: 20
          memory: 24
      labels:
        cluster: cluster
        host: host
        jobid: jobid
```